### PR TITLE
[BUGFIX] fix countdown scheduling again

### DIFF
--- a/leetbot/index.js
+++ b/leetbot/index.js
@@ -77,7 +77,7 @@ const scheduleJobs = ({
     )
   })
   scheduler.scheduleJob(`57 ${leetMinutes - 1} ${leetHours} * * *`, () => {
-    countDown(bot, store)
+    countDown(bot, store, i18n)
   })
   scheduler.scheduleJob(`${leetMinutes + 1} ${leetHours} * * *`, () => {
     dailyReporter(bot, store, i18n)


### PR DESCRIPTION
Add third necessary parameter when calling `countDown` function, should fix the countdown before 1337 being displayed again.